### PR TITLE
Make gzip optional

### DIFF
--- a/tasks/s3-sync.js
+++ b/tasks/s3-sync.js
@@ -24,7 +24,7 @@ module.exports = function(grunt) {
       , db = null
 
     options.headers = options.headers || {}
-    if(!options.headers['Content-Encoding']){
+    if(options.gzip){
       options.headers['Content-Encoding'] = 'gzip'
     }
 


### PR DESCRIPTION
By default the Content-Encoding header was being set. I have changed this to make it optional.
