### PR TITLE
Add support for gzip compression level

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -40,6 +40,12 @@ module.exports = function(grunt) {
                       , dest: 'Gruntfile.js'
                     },
                     {
+                        src 'foo/**/*.css'
+                        dest: 'css/'
+                        gzip: true
+                        compressionLevel: 9
+                    },
+                    {
                         src:  'foo/bar'
                       , dest: 'none'
                     }

--- a/README.md
+++ b/README.md
@@ -73,6 +73,11 @@ Pass this to a files object to enable gzip compression, e.g.
 }
 ```
 
+#### files.compressionLevel
+Type: `Number`
+
+This argument will set compression to the desired level. The default is 6 and the maximum you can set is 9. This is only useful if `gzip: true`. You can find more about this [here](http://zlib.net/manual.html#Advanced).
+
 #### files.root
 Type: `String`
 
@@ -101,7 +106,7 @@ demonstrates loading aws settings from another file, Where grunt-aws.json is jus
 ```js
 grunt.initConfig({
   aws: grunt.file.readJSON('~/grunt-aws.json'),
-  s3-sync: {
+  's3-sync': {
     options: {
         key: '<%= aws.key %>'
       , secret: '<%= aws.secret %>'
@@ -115,6 +120,13 @@ grunt.initConfig({
               , src:  'tasks/**/*.js'
               , dest: 'js/'
               , gzip: true
+            },
+            {
+                root: 'dist'
+              , src: ['dist/**', '!dist/img/**']  // Don't compress images!
+              , dest: '/<%= pkg.version %>/'
+              , gzip: true
+              , compressionLevel: 9  // Max compression
             },
             {
                 root: __dirname

--- a/tasks/s3-sync.js
+++ b/tasks/s3-sync.js
@@ -93,6 +93,7 @@ module.exports = function(grunt) {
         var absolute = path.resolve(src)
         var dest = url.resolve(file.dest, path.relative(file.root, src))
         var useGzip = 'gzip' in file ? !!file.gzip : !!options.gzip
+        var gzipCompLevel =  'compressionLevel' in file ? !!file.compressionLevel : !!options.compressionLevel
 
         if (!useGzip) {
           uploadFile(absolute, absolute, dest)
@@ -104,7 +105,7 @@ module.exports = function(grunt) {
 
         grunt.file.mkdir(path.dirname(outputSrc))
 
-        var gzip = zlib.createGzip()
+        var gzip = zlib.createGzip({ level: gzipCompLevel })
           , input = fs.createReadStream(absolute)
           , output = fs.createWriteStream(outputSrc)
 


### PR DESCRIPTION
I wanted to set the compression level to the maximum, based on the options you can [pass to zlib](http://nodejs.org/api/zlib.html) and [this](http://stackoverflow.com/questions/12467584/how-to-use-node-js-zlib-module-with-options).
Also fixed a typo on the readme. Maybe it would be good to give users the possibility to pass all sort of zlib options, but I think that the compression level is good for most users.
Also gave an example of how not to compress images, because compressing images [is bad](http://developer.yahoo.com/performance/rules.html#gzip). Maybe it would be good to add better docs for the image compression thing in the future.
